### PR TITLE
Support DSN connections and add storage tests

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,32 +1,80 @@
-"""
-This module contains functions to connect to the database
-"""
+"""Utility functions to connect to the database."""
 
 import os
+import sqlite3
+from urllib.parse import urlparse
+
 from dotenv import load_dotenv
 import psycopg2
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
+
+class SQLiteCursorWrapper:
+    """Minimal wrapper translating psycopg2 style placeholders for sqlite."""
+
+    def __init__(self, cursor):
+        self.cursor = cursor
+
+    def execute(self, query, params=None):
+        query = query.replace("%s", "?")
+        return self.cursor.execute(query, params or [])
+
+    def executemany(self, query, seq_of_params):
+        query = query.replace("%s", "?")
+        return self.cursor.executemany(query, seq_of_params)
+
+    def __getattr__(self, name):
+        return getattr(self.cursor, name)
+
+
+class SQLiteConnectionWrapper:
+    """Return a connection mimicking psycopg2's interface for sqlite."""
+
+    def __init__(self, conn):
+        self.conn = conn
+
+    def cursor(self):
+        return SQLiteCursorWrapper(self.conn.cursor())
+
+    def __getattr__(self, name):
+        return getattr(self.conn, name)
+
+
 # Load environment variables
 load_dotenv()
 
-def get_db_connection(dbname=None):
-    """
-    Create a connection to the database
 
-    Returns:
-        psycopg2.connection: Connection to the database
+def get_db_connection(dbname: str | None = None, dsn: str | None = None):
+    """Create a connection to the database.
+
+    The connection parameters are resolved in the following order:
+    1. ``dsn`` argument or ``DATABASE_URL`` environment variable.
+    2. PostgreSQL parameters from environment variables.
     """
+
+    dsn = dsn or os.getenv("DATABASE_URL")
+    if dsn:
+        parsed = urlparse(dsn)
+        scheme = parsed.scheme
+        if scheme.startswith("sqlite"):
+            path = parsed.netloc + parsed.path
+            if path in ("", "/", "/:memory:"):
+                path = ":memory:"
+            conn = sqlite3.connect(path)
+            return SQLiteConnectionWrapper(conn)
+        # Default to psycopg2 for PostgreSQL style DSN
+        return psycopg2.connect(dsn)
+
+    # Fallback to legacy PostgreSQL environment variables
     db_connection = {
-        'dbname': dbname or os.getenv('POSTGRES_DB'),
-        'user': os.getenv('POSTGRES_USER'),
-        'password': os.getenv('POSTGRES_PASSWORD'),
-        'host': 'localhost',
-        'port': '5432'
+        "dbname": dbname or os.getenv("POSTGRES_DB"),
+        "user": os.getenv("POSTGRES_USER"),
+        "password": os.getenv("POSTGRES_PASSWORD"),
+        "host": "localhost",
+        "port": "5432",
     }
 
-    conn = psycopg2.connect(**db_connection)
-    return conn
+    return psycopg2.connect(**db_connection)
 
 def create_database():
     """

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,76 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from db import get_db_connection
+from list_clubs import store_clubs
+from list_athletes import store_athletes, create_athletes_table
+
+
+@pytest.fixture
+def db_dsn(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    dsn = f"sqlite:///{db_file}"
+    monkeypatch.setenv("DATABASE_URL", dsn)
+    yield dsn
+    if db_file.exists():
+        db_file.unlink()
+    log = tmp_path / "log.txt"
+    if log.exists():
+        log.unlink()
+
+
+def test_store_clubs(db_dsn):
+    clubs = {
+        "1": ("Club One", 2000, 2001),
+        "2": ("Club Two", 2002, 2003),
+    }
+    store_clubs(clubs)
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT id, name, first_year, last_year FROM clubs ORDER BY id")
+    rows = cur.fetchall()
+    conn.close()
+    assert rows == [
+        ("1", "Club One", 2000, 2001),
+        ("2", "Club Two", 2002, 2003),
+    ]
+
+
+def test_store_athletes(db_dsn):
+    create_athletes_table()
+    athletes = {
+        "ath1": {
+            "name": "Athlete One",
+            "url": "http://example.com",
+            "birth_date": "2000-01-01",
+            "license_id": "L1",
+            "sexe": "M",
+            "nationality": "FR",
+        }
+    }
+    store_athletes(athletes)
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT id, name, url, birth_date, license_id, sexe, nationality FROM athletes"
+    )
+    rows = cur.fetchall()
+    conn.close()
+    assert rows == [
+        (
+            "ath1",
+            "Athlete One",
+            "http://example.com",
+            "2000-01-01",
+            "L1",
+            "M",
+            "FR",
+        )
+    ]


### PR DESCRIPTION
## Summary
- Allow `get_db_connection` to connect using a DSN string or SQLite for testing
- Verify `store_clubs` and `store_athletes` using a temporary SQLite database

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0232672f083238f740a02ff60b70d