### PR TITLE
feat: add logging and checks to update script

### DIFF
--- a/update_database.sh
+++ b/update_database.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-set -e
+LOG_FILE="update.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
 
 CURRENT_YEAR="$(date +"%Y")"
 CURRENT_MONTH="$(date +"%m")"
@@ -11,11 +12,24 @@ else
     SEASON="$CURRENT_YEAR"
 fi
 
+echo "$(date) - Début de la mise à jour (saison $SEASON)"
 echo "🚀 Mise à jour de la base athlé - Saison ${SEASON}"
 echo "📥 Mise à jour des clubs..."
-python list_clubs.py
+if python list_clubs.py; then
+    echo "$(date) - Mise à jour des clubs réussie"
+else
+    echo "$(date) - Échec de la mise à jour des clubs"
+    exit 1
+fi
 
 echo "🏃 Mise à jour des athlètes pour la saison ${SEASON}..."
-python list_athletes.py --first-year "${SEASON}"
+if athletes=$(python list_athletes.py --first-year "${SEASON}"); then
+    echo "$(date) - Athlètes retournés : $athletes"
+    echo "$(date) - Mise à jour des athlètes réussie"
+else
+    echo "$(date) - Échec de la mise à jour des athlètes"
+    exit 1
+fi
 
 echo "✅ Mise à jour terminée avec succès !"
+echo "$(date) - Fin de la mise à jour"


### PR DESCRIPTION
## Summary
- log update process to `update.log` with timestamps
- capture number of athletes and record success or failure for each step

## Testing
- `bash -n update_database.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b03215aa2c8323aac649e1f17a1c6e