### PR TITLE
feat: Enhance scraper final summary with pretty formatting

### DIFF
--- a/scraper/list_athletes.py
+++ b/scraper/list_athletes.py
@@ -8,6 +8,7 @@ import re
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
+from time import time
 
 import psycopg2
 import requests
@@ -551,6 +552,7 @@ def process_clubs_and_athletes(first_year: int, last_year: int, club_id: str) ->
         last_year (int): The last year
         club_id (str): The club FFA ID
     """
+    start_time = time()
     try:
         ensure_schema_exists()
         logger.info("Processing years from %s to %s", first_year, last_year)
@@ -575,6 +577,21 @@ def process_clubs_and_athletes(first_year: int, last_year: int, club_id: str) ->
                     raise
                 athletes = extract_athletes_from_club(year, club_ffa_id)
                 store_athletes(athletes)
+
+        # Print final summary
+        duration = time() - start_time
+        hours = int(duration // 3600)
+        minutes = int((duration % 3600) // 60)
+        seconds = int(duration % 60)
+
+        logger.info("=" * 80)
+        logger.info("✅ SCRAPING TERMINÉ")
+        logger.info("=" * 80)
+        logger.info("📊 Athlètes ajoutés : %s", f"{total_athletes:,}".replace(",", " "))
+        logger.info("📅 Période traitée : %s - %s", first_year, last_year)
+        logger.info("⏱️  Durée : %dh %02dmin %02ds", hours, minutes, seconds)
+        logger.info("=" * 80)
+
     except KeyboardInterrupt:
         logger.error("Interrupted by user")
         raise
@@ -616,7 +633,6 @@ def main():
         update_athletes_info()
     else:
         process_clubs_and_athletes(first_year, last_year, args.club_id)
-        logger.info("Scrapping terminé : %s athlètes", total_athletes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 📋 Description

Améliore le résumé final du scraper avec un formatage plus lisible et informatif.

## ✨ Changements

- ✅ Ajout du calcul de durée d'exécution (heures, minutes, secondes)
- ✅ Formatage du nombre d'athlètes avec séparateurs de milliers (format français : `940 868`)
- ✅ Affichage de la période traitée (année de début et de fin)
- ✅ Ajout de séparateurs visuels et emojis pour meilleure lisibilité
- ✅ Suppression du log en doublon dans `main()`

## 📊 Exemple de sortie

Avant :
```
INFO - Scraping terminé : 940868 athlètes ajoutés
```

Après :
```
INFO - ================================================================================
INFO - ✅ SCRAPING TERMINÉ
INFO - ================================================================================
INFO - 📊 Athlètes ajoutés : 940 868
INFO - 📅 Période traitée : 2004 - 2025
INFO - ⏱️  Durée : 2h 34min 12s
INFO - ================================================================================
```

## 🧪 Tests

- [ ] Tester en local avec `python -m scraper.list_athletes --first-year 2024 --last-year 2024 --club-id XXX`
- [ ] Vérifier que le formatage s'affiche correctement dans les logs
- [ ] Déployer en staging pour validation

## 📝 Notes

Le résumé est affiché à la fin de `process_clubs_and_athletes()`, juste après le traitement de tous les clubs et athlètes. Le timing démarre au début de la fonction et se termine à la fin du traitement.